### PR TITLE
yajl_validator for stream projection

### DIFF
--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -474,7 +474,6 @@ static VALUE rb_yajl_parser_init(int argc, VALUE * argv, VALUE self) {
  * block is for this method.
 */
 static VALUE rb_yajl_parser_parse(int argc, VALUE * argv, VALUE self) {
-    yajl_status stat;
     yajl_parser_wrapper * wrapper;
     VALUE rbufsize, input, blk;
     unsigned int len;
@@ -509,7 +508,7 @@ static VALUE rb_yajl_parser_parse(int argc, VALUE * argv, VALUE self) {
     }
 
     /* parse any remaining buffered data */
-    stat = yajl_parse_complete(wrapper->parser);
+    yajl_parse_complete(wrapper->parser);
 
     if (wrapper->parse_complete_callback != Qnil) {
         yajl_check_and_fire_callback((void *)self);

--- a/ext/yajl/yajl_ext.c
+++ b/ext/yajl/yajl_ext.c
@@ -631,7 +631,10 @@ static yajl_event_t yajl_event_stream_next(yajl_event_stream_t parser, int pop) 
         }
 
         //printf("popping\n");
-        token = yajl_lex_lex(parser->lexer, (const unsigned char *)RSTRING_PTR(parser->buffer), RSTRING_LEN(parser->buffer), &parser->offset, (const unsigned char **)&event.buf, &event.len);
+        token = yajl_validator_lex(parser->validator, (const unsigned char *)RSTRING_PTR(parser->buffer), RSTRING_LEN(parser->buffer), &parser->offset, (const unsigned char **)&event.buf, &event.len);
+        if (parser->validator->error) {
+          rb_raise(cParseError, "invalid JSON token sequence");
+        }
         //printf("popped event %d\n", token);
 
         if (token == yajl_tok_eof) {

--- a/ext/yajl/yajl_validator.c
+++ b/ext/yajl/yajl_validator.c
@@ -1,0 +1,291 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+
+#include "yajl_alloc.h"
+#include "yajl_lex.h"
+#include "yajl_validator.h"
+
+// private headers
+
+static const char * yajl_tok_name(yajl_tok);
+
+static const char * yajl_validator_context_name(yajl_validator_context);
+
+static const char * yajl_validator_state_name(yajl_validator_state);
+
+void yajl_validator_token(struct yajl_validator *, yajl_tok);
+
+yajl_validator_context yajl_validator_ctx(struct yajl_validator *);
+
+void yajl_validator_ctx_push(struct yajl_validator *, yajl_validator_context);
+
+void yajl_validator_ctx_pop(struct yajl_validator *);
+
+void yajl_validator_state_set(struct yajl_validator *, yajl_validator_state);
+
+// functions
+
+void yajl_validator_init(struct yajl_validator * val, yajl_lexer lexer) {
+  val->lexer = lexer;
+  val->ctx_stack[0] = yajl_validator_context_root;
+  val->ctx_stack_depth = 0;
+  val->state = yajl_validator_state_root;
+  val->error = 0;
+}
+
+yajl_tok yajl_validator_lex(
+  struct yajl_validator * val,
+  const unsigned char * jsonText,
+  unsigned int jsonTextLen,
+  unsigned int * offset,
+  const unsigned char ** outBuf,
+  unsigned int * outLen
+) {
+  yajl_tok tok = yajl_lex_lex(
+    val->lexer,
+    jsonText,
+    jsonTextLen,
+    offset,
+    outBuf,
+    outLen
+  );
+
+  // EOF special-cased because this is a chunking parser.
+  if (tok != yajl_tok_eof) {
+    yajl_validator_token(val, tok);
+  }
+
+  return tok;
+}
+
+static const char *
+yajl_tok_name(yajl_tok tok) 
+{
+    switch (tok) {
+        case yajl_tok_bool: return "bool";
+        case yajl_tok_colon: return "colon";
+        case yajl_tok_comma: return "comma";
+        case yajl_tok_comment: return "comment";
+        case yajl_tok_eof: return "eof";
+        case yajl_tok_error: return "error";
+        case yajl_tok_left_brace: return "open_array"; // [
+        case yajl_tok_left_bracket: return "open_object"; // {
+        case yajl_tok_null: return "null";
+        case yajl_tok_integer: return "integer";
+        case yajl_tok_double: return "double";
+        case yajl_tok_right_brace: return "close_array"; // ]
+        case yajl_tok_right_bracket: return "close_object"; // }
+        case yajl_tok_string: return "string";
+        case yajl_tok_string_with_escapes: return "string_with_escapes";
+        default: assert(0);
+    }
+}
+
+static const char *
+yajl_validator_context_name(yajl_validator_context ctx) 
+{
+    switch (ctx) {
+      case yajl_validator_context_root: return "root";
+      case yajl_validator_context_array: return "array";
+      case yajl_validator_context_object: return "object";
+      default: assert(0);
+    }
+}
+
+static const char *
+yajl_validator_state_name(yajl_validator_state state) 
+{
+    switch (state) {
+      case yajl_validator_state_root: return "root";
+      case yajl_validator_state_root_done: return "root_done";
+      case yajl_validator_state_array: return "array";
+      case yajl_validator_state_array_have_value: return "array_have_value";
+      case yajl_validator_state_object: return "object";
+      case yajl_validator_state_object_have_key: return "object_have_key";
+      case yajl_validator_state_object_have_sep: return "object_have_sep";
+      case yajl_validator_state_object_have_value: return "object_have_value";
+      default: assert(0);
+    }
+}
+
+int yajl_validator_tok_is_terminal(yajl_tok t) {
+  return t == yajl_tok_eof || t == yajl_tok_error;
+}
+
+void yajl_validator_token(struct yajl_validator * val, yajl_tok tok) {
+  yajl_validator_context ctx = yajl_validator_ctx(val);
+  yajl_validator_state state = val->state;
+  printf(
+    "context:%s (depth:%d)  state:%s\n",
+    yajl_validator_context_name(ctx),
+    val->ctx_stack_depth,
+    yajl_validator_state_name(state)
+  );
+  printf("  token: %s\n", yajl_tok_name(tok));
+  yajl_validator_state_name(state);
+  yajl_validator_context_name(ctx);
+
+  switch (state) {
+    case yajl_validator_state_root:
+      switch (tok) {
+        case yajl_tok_left_brace: // [
+          yajl_validator_ctx_push(val, yajl_validator_context_array);
+          yajl_validator_state_set(val, yajl_validator_state_array);
+          break;
+        case yajl_tok_left_bracket: // {
+          yajl_validator_ctx_push(val, yajl_validator_context_object);
+          yajl_validator_state_set(val, yajl_validator_state_object);
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    case yajl_validator_state_root_done:
+      switch (tok) {
+        case yajl_tok_eof:
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    case yajl_validator_state_array:
+      switch (tok) {
+        case yajl_tok_bool:
+        case yajl_tok_null:
+        case yajl_tok_integer:
+        case yajl_tok_double:
+        case yajl_tok_left_brace: // [
+        case yajl_tok_left_bracket: // {
+        case yajl_tok_string:
+        case yajl_tok_string_with_escapes:
+          yajl_validator_state_set(val, yajl_validator_state_array_have_value);
+          break;
+        case yajl_tok_right_brace: // ]
+          yajl_validator_ctx_pop(val);
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    case yajl_validator_state_array_have_value:
+      switch (tok) {
+        case yajl_tok_comma:
+          yajl_validator_state_set(val, yajl_validator_state_array);
+          break;
+        case yajl_tok_right_brace: // ]
+          yajl_validator_ctx_pop(val);
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    case yajl_validator_state_object:
+      switch (tok) {
+        case yajl_tok_right_bracket: // }
+          yajl_validator_ctx_pop(val);
+          break;
+        case yajl_tok_string:
+        case yajl_tok_string_with_escapes:
+          yajl_validator_state_set(val, yajl_validator_state_object_have_key);
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    case yajl_validator_state_object_have_key:
+      switch (tok) {
+        case yajl_tok_colon:
+          yajl_validator_state_set(val, yajl_validator_state_object_have_sep);
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    case yajl_validator_state_object_have_sep:
+      switch (tok) {
+        case yajl_tok_bool:
+          yajl_validator_state_set(val, yajl_validator_state_object_have_value);
+          break;
+        case yajl_tok_comment:
+          val->error = 1;
+          break;
+        case yajl_tok_left_brace: // [
+          yajl_validator_ctx_push(val, yajl_validator_context_array);
+          yajl_validator_state_set(val, yajl_validator_state_array);
+          break;
+        case yajl_tok_left_bracket: // {
+          yajl_validator_ctx_push(val, yajl_validator_context_object);
+          yajl_validator_state_set(val, yajl_validator_state_object);
+          break;
+        case yajl_tok_null:
+        case yajl_tok_integer:
+        case yajl_tok_double:
+        case yajl_tok_string:
+        case yajl_tok_string_with_escapes:
+          yajl_validator_state_set(val, yajl_validator_state_object_have_value);
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    case yajl_validator_state_object_have_value:
+      switch (tok) {
+        case yajl_tok_comma:
+          yajl_validator_state_set(val, yajl_validator_state_object);
+          break;
+        case yajl_tok_right_bracket: // }
+          yajl_validator_ctx_pop(val);
+          break;
+        default:
+          val->error = 1;
+          break;
+      }
+      break;
+    default: assert(0); // all cases handled
+  }
+}
+
+yajl_validator_context yajl_validator_ctx(struct yajl_validator * val) {
+  return val->ctx_stack[val->ctx_stack_depth];
+}
+
+void yajl_validator_ctx_push(struct yajl_validator * val, yajl_validator_context ctx) {
+  printf("    pushing context: %s\n", yajl_validator_context_name(ctx));
+  val->ctx_stack_depth++;
+  val->ctx_stack[val->ctx_stack_depth] = ctx;
+}
+
+void yajl_validator_ctx_pop(struct yajl_validator * val) {
+  assert(val->ctx_stack_depth > 0);
+  val->ctx_stack_depth--;
+  yajl_validator_context ctx = val->ctx_stack[val->ctx_stack_depth];
+  printf("    popped into context: %s\n", yajl_validator_context_name(ctx));
+  switch (ctx) {
+    case yajl_validator_context_root:
+      yajl_validator_state_set(val, yajl_validator_state_root_done);
+      break;
+    case yajl_validator_context_array:
+      yajl_validator_state_set(val, yajl_validator_state_array_have_value);
+      break;
+    case yajl_validator_context_object:
+      yajl_validator_state_set(val, yajl_validator_state_object_have_value);
+      break;
+    default:
+      assert(0);
+      break;
+  }
+}
+
+void yajl_validator_state_set(struct yajl_validator * val, yajl_validator_state state) {
+  printf("    setting state: %s\n", yajl_validator_state_name(state));
+  val->state = state;
+}

--- a/ext/yajl/yajl_validator.c
+++ b/ext/yajl/yajl_validator.c
@@ -117,13 +117,13 @@ int yajl_validator_tok_is_terminal(yajl_tok t) {
 void yajl_validator_token(struct yajl_validator * val, yajl_tok tok) {
   yajl_validator_context ctx = yajl_validator_ctx(val);
   yajl_validator_state state = val->state;
-  printf(
-    "context:%s (depth:%d)  state:%s\n",
-    yajl_validator_context_name(ctx),
-    val->ctx_stack_depth,
-    yajl_validator_state_name(state)
-  );
-  printf("  token: %s\n", yajl_tok_name(tok));
+  // printf(
+  //   "context:%s (depth:%d)  state:%s\n",
+  //   yajl_validator_context_name(ctx),
+  //   val->ctx_stack_depth,
+  //   yajl_validator_state_name(state)
+  // );
+  // printf("  token: %s\n", yajl_tok_name(tok));
   yajl_validator_state_name(state);
   yajl_validator_context_name(ctx);
 
@@ -265,7 +265,7 @@ yajl_validator_context yajl_validator_ctx(struct yajl_validator * val) {
 }
 
 void yajl_validator_ctx_push(struct yajl_validator * val, yajl_validator_context ctx) {
-  printf("    pushing context: %s\n", yajl_validator_context_name(ctx));
+  // printf("    pushing context: %s\n", yajl_validator_context_name(ctx));
   val->ctx_stack_depth++;
   val->ctx_stack[val->ctx_stack_depth] = ctx;
 }
@@ -274,7 +274,7 @@ void yajl_validator_ctx_pop(struct yajl_validator * val) {
   assert(val->ctx_stack_depth > 0);
   val->ctx_stack_depth--;
   yajl_validator_context ctx = val->ctx_stack[val->ctx_stack_depth];
-  printf("    popped into context: %s\n", yajl_validator_context_name(ctx));
+  // printf("    popped into context: %s\n", yajl_validator_context_name(ctx));
   switch (ctx) {
     case yajl_validator_context_root:
       yajl_validator_state_set(val, yajl_validator_state_root_done);
@@ -292,6 +292,6 @@ void yajl_validator_ctx_pop(struct yajl_validator * val) {
 }
 
 void yajl_validator_state_set(struct yajl_validator * val, yajl_validator_state state) {
-  printf("    setting state: %s\n", yajl_validator_state_name(state));
+  // printf("    setting state: %s\n", yajl_validator_state_name(state));
   val->state = state;
 }

--- a/ext/yajl/yajl_validator.c
+++ b/ext/yajl/yajl_validator.c
@@ -158,11 +158,17 @@ void yajl_validator_token(struct yajl_validator * val, yajl_tok tok) {
         case yajl_tok_null:
         case yajl_tok_integer:
         case yajl_tok_double:
-        case yajl_tok_left_brace: // [
-        case yajl_tok_left_bracket: // {
         case yajl_tok_string:
         case yajl_tok_string_with_escapes:
           yajl_validator_state_set(val, yajl_validator_state_array_have_value);
+          break;
+        case yajl_tok_left_brace: // [
+          yajl_validator_ctx_push(val, yajl_validator_context_array);
+          yajl_validator_state_set(val, yajl_validator_state_array);
+          break;
+        case yajl_tok_left_bracket: // {
+          yajl_validator_ctx_push(val, yajl_validator_context_object);
+          yajl_validator_state_set(val, yajl_validator_state_object);
           break;
         case yajl_tok_right_brace: // ]
           yajl_validator_ctx_pop(val);

--- a/ext/yajl/yajl_validator.h
+++ b/ext/yajl/yajl_validator.h
@@ -1,0 +1,52 @@
+#ifndef __YAJL_VALIDATOR_H__
+#define __YAJL_VALIDATOR_H__
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "yajl_lex.h"
+
+// types
+
+typedef enum {
+  yajl_validator_context_root,
+  yajl_validator_context_array,
+  yajl_validator_context_object,
+} yajl_validator_context;
+
+typedef enum {
+  yajl_validator_state_root,
+  yajl_validator_state_root_done,
+  yajl_validator_state_array,
+  yajl_validator_state_array_have_value,
+  yajl_validator_state_object,
+  yajl_validator_state_object_have_key,
+  yajl_validator_state_object_have_sep,
+  yajl_validator_state_object_have_value,
+} yajl_validator_state;
+
+struct yajl_validator {
+  yajl_lexer lexer;
+  yajl_validator_context ctx_stack[256]; // TODO: dynamic stack
+  uint8_t ctx_stack_depth;               // TODO: dynamic stack
+  yajl_validator_state state;
+  int error;
+};
+
+// functions
+
+void yajl_validator_init(struct yajl_validator * val, yajl_lexer lexer);
+
+yajl_tok yajl_validator_lex(
+  struct yajl_validator * val,
+  const unsigned char * jsonText,
+  unsigned int jsonTextLen,
+  unsigned int * offset,
+  const unsigned char ** outBuf,
+  unsigned int * outLen
+);
+
+int yajl_validator_tok_is_terminal(yajl_tok);
+
+#endif


### PR DESCRIPTION
Introduces `yajl_validator`, a decorator-ish for `yajl_lex_lex` which validates the sequential validity of tokens via a stack-tracking state machine. Unexpected tokens do not interrupt lexing, but set `validator->error` which can be cleared by the caller between tokens if desired. EOF (`yajl_tok_eof`) bypasses the validator due to its special role in chunked parsing; it's already special-cased in the underlying `yajl_lex_lex`.

Stream Projection now uses `yajl_validator` with a single error flag check instead of complex ad-hoc token sequence validation. However this currently means a regression in the helpfulness of error messages. This can be solved centrally in `yajl_validator` with a little more work. 

All current specs pass (including Stream Projection specs) however `yajl_validator` could do with more valid and invalid test cases.